### PR TITLE
Shrink unsafe blocks for the Archetype/World impl

### DIFF
--- a/src/query_one.rs
+++ b/src/query_one.rs
@@ -37,10 +37,10 @@ impl<'a, Q: Query> QueryOne<'a, Q> {
         if self.borrowed {
             panic!("called QueryOnce::get twice; construct a new query instead");
         }
+        let fetch = Q::Fetch::new(self.archetype)?;
+        self.borrowed = true;
+        Q::Fetch::borrow(self.archetype);
         unsafe {
-            let fetch = Q::Fetch::new(self.archetype)?;
-            self.borrowed = true;
-            Q::Fetch::borrow(self.archetype);
             Some(fetch.get(self.index as usize))
         }
     }


### PR DESCRIPTION
In this impl you use the unsafe keyword for many safe expressions. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 